### PR TITLE
feat: add EthMRequest::<N>::from_iter method

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ndisapi-rs"
-version = "0.4.2"
+version = "0.4.3"
 edition = "2021"
 authors = ["Vadim Smirnov <vadim@ntkernel.com>"]
 description = "Rust crate for interacting with the Windows Packet Filter driver (NDISAPI)"

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Add the following to your `Cargo.toml` file:
 
 ```toml
 [dependencies]
-ndisapi-rs = "0.4.2"
+ndisapi-rs = "0.4.3"
 ```
 
 ## Usage

--- a/src/async_api.rs
+++ b/src/async_api.rs
@@ -196,12 +196,7 @@ impl AsyncNdisapiAdapter {
         let driver = self.driver.clone();
 
         // Initialize EthMPacket to pass to driver API.
-        let mut request = ndisapi::EthMRequest::<N>::new(self.adapter_handle);
-
-        // Initialize the read EthMRequest object.
-        for ib in packets {
-            request.push(ib)?;
-        }
+        let mut request = ndisapi::EthMRequest::<N>::from_iter(self.adapter_handle, packets);
 
         // first try to read packets
         if driver.read_packets(&mut request).is_ok() {
@@ -297,12 +292,7 @@ impl AsyncNdisapiAdapter {
         I: Iterator<Item = &'a mut IntermediateBuffer>,
     {
         // Initialize EthMPacket to pass to driver API.
-        let mut request = ndisapi::EthMRequest::<N>::new(self.adapter_handle);
-
-        // Initialize the EthMRequest object.
-        for ib in packets {
-            request.push(ib)?;
-        }
+        let request = ndisapi::EthMRequest::<N>::from_iter(self.adapter_handle, packets);
 
         // Try to send packets to the network adapter.
         if self.driver.send_packets_to_adapter(&request).is_ok() {
@@ -375,12 +365,7 @@ impl AsyncNdisapiAdapter {
         I: Iterator<Item = &'a mut IntermediateBuffer>,
     {
         // Initialize EthMPacket to pass to driver API.
-        let mut request = ndisapi::EthMRequest::<N>::new(self.adapter_handle);
-
-        // Initialize the EthMRequest object.
-        for ib in packets {
-            request.push(ib)?;
-        }
+        let request = ndisapi::EthMRequest::<N>::from_iter(self.adapter_handle, packets);
 
         // Try to send packets upwards the network stack.
         if self.driver.send_packets_to_mstcp(&request).is_ok() {


### PR DESCRIPTION
This commit introduces a new method to the EthMRequest struct, allowing for construction from an iterator over `&mut IntermediateBuffer`. This  adds more flexibility in creating EthMRequest instances.

fix: correct behavior in EthMRequest::<N>::set_packet method This commit fixes a bug in the set_packet method in the EthMRequest struct. These corrections ensure proper packet management and error handling in full buffer scenarios.