### PR TITLE
Harden Win32 FFI boundary and fix safety/correctness issues (0.7.0)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ndisapi"
-version = "0.6.6"
+version = "0.7.0"
 edition = "2021"
 authors = ["Vadim Smirnov <vadim@ntkernel.com>"]
 description = "Rust crate for interacting with the Windows Packet Filter driver (NDISAPI)"

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Add the following to your `Cargo.toml` file:
 
 ```toml
 [dependencies]
-ndisapi = "0.6.6"
+ndisapi = "0.7.0"
 ```
 
 ## Usage

--- a/examples/async-packthru.rs
+++ b/examples/async-packthru.rs
@@ -285,7 +285,7 @@ impl PacketInfo {
     /// All other fields are set to `None` because they are not applicable to ARP packets.
     fn handle_arp_packet(eth_hdr: &EthernetFrame<&[u8]>) -> PacketInfo {
         let arp_packet = ArpPacket::new_unchecked(eth_hdr.payload());
-        
+
         // Convert slices to fixed-size arrays
         let src_bytes: [u8; 4] = arp_packet
             .source_protocol_addr()
@@ -295,7 +295,7 @@ impl PacketInfo {
             .target_protocol_addr()
             .try_into()
             .unwrap_or([0u8; 4]);
-        
+
         PacketInfo {
             ethertype: EthernetProtocol::Arp,
             src_addr: Some(IpAddress::Ipv4(Ipv4Address::from_octets(src_bytes))),

--- a/examples/listadapters.rs
+++ b/examples/listadapters.rs
@@ -82,7 +82,9 @@ fn main() -> Result<()> {
             OID_802_3_CURRENT_ADDRESS,
             MacAddress::default(),
         );
-        if let Err(err) = driver.ndis_get_request::<_>(&mut current_address_request) {
+        // SAFETY: `MacAddress` wraps `[u8; 6]`, a plain-old-data type for which every byte
+        // pattern returned by the driver is a valid value.
+        if let Err(err) = unsafe { driver.ndis_get_request::<_>(&mut current_address_request) } {
             println!("Getting OID_802_3_CURRENT_ADDRESS Error: {}", err.message(),)
         } else {
             println!(

--- a/src/async_api.rs
+++ b/src/async_api.rs
@@ -20,7 +20,7 @@ use std::sync::Arc;
 use windows::{
     core::Result,
     Win32::{
-        Foundation::{HANDLE, WIN32_ERROR},
+        Foundation::{CloseHandle, HANDLE, WIN32_ERROR},
         System::Threading::CreateEventW,
     },
 };
@@ -78,13 +78,26 @@ impl AsyncNdisapiAdapter {
             CreateEventW(None, true, false, None)?
         };
 
-        // Setting the event for packet capture for the specified adapter.
+        // Hand the event to the `Win32EventStream` first. On success the stream owns the handle
+        // (and its wait registration) and closes it in its own `Drop`. If the stream cannot be
+        // created the handle is not yet owned by anything, so close it here to avoid leaking it.
+        let notif = match Win32EventStream::new(event_handle) {
+            Ok(notif) => notif,
+            Err(e) => {
+                let _ = unsafe { CloseHandle(event_handle) };
+                return Err(e);
+            }
+        };
+
+        // Register the event with the driver for packet-capture notifications. If this fails,
+        // `notif` is dropped, which unregisters the wait and closes the event handle — so the
+        // handle does not leak on this path either.
         driver.set_packet_event(adapter_handle, event_handle)?;
 
         Ok(Self {
             adapter_handle,
             driver,
-            notif: Win32EventStream::new(event_handle)?, // Creating a new Win32EventStream with the event handle.
+            notif,
         })
     }
 
@@ -227,7 +240,7 @@ impl AsyncNdisapiAdapter {
     /// # Arguments
     ///
     /// * `packet` - An `IntermediateBuffer` that will be encapsulated in an `EthPacket`
-    /// representing the Ethernet packet to be sent.
+    ///   representing the Ethernet packet to be sent.
     ///
     /// # Safety
     ///
@@ -277,7 +290,7 @@ impl AsyncNdisapiAdapter {
     ///
     /// # Returns
     ///
-    /// On successful operation, this function returns an `Ok(usize)` that represents the number of packets successfully sent to the network adapter. If the operation fails, an error is returned.
+    /// On successful operation, this function returns an `Ok(usize)` with the number of packets that were submitted to the driver for sending. If the operation fails, an error is returned.
     pub fn send_packets_to_adapter<'a, const N: usize>(
         &mut self,
         packets: impl IntoIterator<Item = &'a IntermediateBuffer>,
@@ -287,10 +300,14 @@ impl AsyncNdisapiAdapter {
             ndisapi::EthMRequest::<N>::from_iter(self.adapter_handle, packets.into_iter());
 
         // Try to send packets to the network adapter.
-        match self.driver.send_packets_to_adapter(&request) {
-            Ok(_) => Ok(request.get_packet_success() as usize),
-            Err(err) => Err(err),
-        }
+        //
+        // The send IOCTL takes no output buffer, so the driver never writes back the
+        // `packet_success` counter (unlike the read path); it would always read as 0 here.
+        // Report the number of packets submitted in the request instead, which is the
+        // meaningful value on the success path.
+        self.driver
+            .send_packets_to_adapter(&request)
+            .map(|_| request.get_packet_number() as usize)
     }
 
     /// Sends an Ethernet packet upwards through the network stack to the Microsoft TCP/IP protocol driver.
@@ -346,7 +363,7 @@ impl AsyncNdisapiAdapter {
     ///
     /// # Returns
     ///
-    /// On successful operation, this function returns `Ok(usize)`, where `usize` is the number of packets sent. If the operation fails, an error is returned.
+    /// On successful operation, this function returns `Ok(usize)`, where `usize` is the number of packets submitted to the driver for sending. If the operation fails, an error is returned.
     pub fn send_packets_to_mstcp<'a, const N: usize>(
         &mut self,
         packets: impl IntoIterator<Item = &'a IntermediateBuffer>,
@@ -356,10 +373,13 @@ impl AsyncNdisapiAdapter {
             ndisapi::EthMRequest::<N>::from_iter(self.adapter_handle, packets.into_iter());
 
         // Try to send packets upwards the network stack.
-        match self.driver.send_packets_to_mstcp(&request) {
-            Ok(_) => Ok(request.get_packet_success() as usize),
-            Err(err) => Err(err),
-        }
+        //
+        // As with `send_packets_to_adapter`, the send IOCTL has no output buffer, so
+        // `packet_success` is never populated by the driver. Return the number of packets
+        // submitted in the request rather than the always-zero success counter.
+        self.driver
+            .send_packets_to_mstcp(&request)
+            .map(|_| request.get_packet_number() as usize)
     }
 }
 

--- a/src/async_api/win32_event_stream.rs
+++ b/src/async_api/win32_event_stream.rs
@@ -36,7 +36,7 @@ use std::{
 use windows::{
     core::Result,
     Win32::{
-        Foundation::{CloseHandle, HANDLE},
+        Foundation::{CloseHandle, HANDLE, INVALID_HANDLE_VALUE},
         System::Threading::{
             RegisterWaitForSingleObject, ResetEvent, UnregisterWaitEx, INFINITE,
             WT_EXECUTEINWAITTHREAD,
@@ -89,14 +89,18 @@ impl Stream for Win32EventStream {
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let this = Pin::into_inner(self);
 
-        if this.ready.swap(false, Ordering::Relaxed) {
-            // The Win32 event is ready, so we clear the ready flag and wake the waker, if present.
-            // Then we reset the event to non-signaled state.
-            // We signal readiness by returning `Poll::Ready`.
+        // Register the waker *before* checking readiness. The callback always stores `true` into
+        // `ready` and only then calls `waker.wake()`. By registering first and re-checking, a
+        // signal that fires between the check and the registration cannot be lost: either we
+        // observe `ready == true` here, or the callback's `wake()` targets the waker we just
+        // registered. (The previous order — check then register — could sleep forever if the
+        // event was signaled in the gap between the two.)
+        this.waker.register(cx.waker());
+
+        if this.ready.swap(false, Ordering::SeqCst) {
+            // The Win32 event was signaled; clear the flag and report readiness.
             Poll::Ready(Some(Ok(())))
         } else {
-            // The Win32 event is not ready, so we register the waker and return `Poll::Pending`.
-            this.waker.register(cx.waker());
             Poll::Pending
         }
     }
@@ -165,18 +169,33 @@ impl Win32EventNotification {
 impl Drop for Win32EventNotification {
     /// Implementing the Drop trait for the Win32EventNotification struct.
     fn drop(&mut self) {
-        unsafe {
-            // Deregistering the wait object.
-            if UnregisterWaitEx(self.wait_object, Some(self.win32_event)).is_err() {
-                //log::error!("error deregistering notification: {}", GetLastError);
+        // Deregister the wait and *block until any in-flight callback has finished*. Passing
+        // `INVALID_HANDLE_VALUE` as the completion event makes `UnregisterWaitEx` wait for
+        // outstanding callbacks to complete before returning. Only once that succeeds is it
+        // safe to free the callback box and close the event.
+        //
+        // Passing the event handle itself (as the original code did) merely asks the OS to
+        // signal that event on completion *without* waiting; tearing down a registered wait
+        // while it is still pending is explicitly undefined per the
+        // `RegisterWaitForSingleObject` documentation.
+        match unsafe { UnregisterWaitEx(self.wait_object, Some(INVALID_HANDLE_VALUE)) } {
+            Ok(()) => {
+                // The wait is gone and no callback can be running, so the boxed callback can be
+                // dropped and the event handle closed safely.
+                drop(unsafe { Box::from_raw(self.callback) });
+                let _ = unsafe { CloseHandle(self.win32_event) };
             }
-            drop(Box::from_raw(self.callback)); // Dropping the callback function.
+            Err(_e) => {
+                // Deregistration failed, so we cannot prove that the wait is gone or that no
+                // callback is (or will later be) running. Freeing the callback box or closing
+                // the event here would risk a use-after-free of the callback and a
+                // use-after-close of the event handle (the callback also touches the event via
+                // `ResetEvent`). A leak is strictly preferable to undefined behavior, so we
+                // deliberately leak both the callback allocation and the event handle on this
+                // (expected-to-be-unreachable) path.
+                //log::error!("error deregistering notification: {_e}");
+            }
         }
-
-        let _ = unsafe {
-            // Closing the handle to the event.
-            CloseHandle(self.win32_event)
-        };
     }
 }
 

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -14,7 +14,7 @@
 //!   the conditions for filtering at specific layers.
 //!
 //! * [`base`] - Provides Rust equivalents of several structures used in the NDISAPI Rust library
-//!   for communicating with the Windows Packet Filter driver. he structures in this submodule are related
+//!   for communicating with the Windows Packet Filter driver. The structures in this submodule are related
 //!   to network adapters, Ethernet packets, adapter events, and Remote Access Service (RAS) links.
 //!
 //! * [`ioctl`] - Provides a collection of constants for IOCTL (Input/Output Control) codes and

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -10,25 +10,25 @@
 //! # Submodules
 //!
 //! * [`constants`] - Provides various constants and bitflag structures used to configure the
-//! packet filtering mechanism, specify filtering options for different protocols, and define
-//! the conditions for filtering at specific layers.
+//!   packet filtering mechanism, specify filtering options for different protocols, and define
+//!   the conditions for filtering at specific layers.
 //!
 //! * [`base`] - Provides Rust equivalents of several structures used in the NDISAPI Rust library
-//! for communicating with the Windows Packet Filter driver. he structures in this submodule are related
-//! to network adapters, Ethernet packets, adapter events, and Remote Access Service (RAS) links.
+//!   for communicating with the Windows Packet Filter driver. he structures in this submodule are related
+//!   to network adapters, Ethernet packets, adapter events, and Remote Access Service (RAS) links.
 //!
 //! * [`ioctl`] - Provides a collection of constants for IOCTL (Input/Output Control) codes and
-//! the `ctl_code` function used to generate these codes. IOCTL codes are used to communicate
-//! with the Windows Packet Filter driver to perform various operations.
+//!   the `ctl_code` function used to generate these codes. IOCTL codes are used to communicate
+//!   with the Windows Packet Filter driver to perform various operations.
 //!
 //! * [`filters`] - Provides structures for specifying filter conditions and actions for various protocols,
-//! including Ethernet 802.3, IPv4, IPv6, TCP, UDP, and ICMP. These structures allow users to define complex
-//! filtering rules based on multiple packet fields and layers.
+//!   including Ethernet 802.3, IPv4, IPv6, TCP, UDP, and ICMP. These structures allow users to define complex
+//!   filtering rules based on multiple packet fields and layers.
 //!
 //! * [`fastio`] - Provides Rust equivalents of several structures related to Fast I/O operations
-//! for the NDISAPI Rust library used in communicating with the Windows Packet Filter driver.
-//! The structures in this submodule are related to Fast I/O sections, which include headers and packet data,
-//! and are involved in read and write operations.
+//!   for the NDISAPI Rust library used in communicating with the Windows Packet Filter driver.
+//!   The structures in this submodule are related to Fast I/O sections, which include headers and packet data,
+//!   and are involved in read and write operations.
 //!
 
 // Submodules

--- a/src/driver/base.rs
+++ b/src/driver/base.rs
@@ -161,26 +161,36 @@ impl IntermediateBuffer {
 
     /// Sets the length of the packet data stored in the `IntermediateBuffer`.
     ///
+    /// The value is clamped to `MAX_ETHER_FRAME` (the capacity of the underlying buffer) so that
+    /// a subsequent call to [`get_data`](Self::get_data) or [`get_data_mut`](Self::get_data_mut)
+    /// can never panic with an out-of-bounds slice.
+    ///
     /// # Arguments
     /// * `length`: A `u32` value representing the new length of the packet data.
     pub fn set_length(&mut self, length: u32) {
-        self.length = length
+        self.length = length.min(MAX_ETHER_FRAME as u32);
     }
 
     /// Returns a reference to the data stored in the buffer.
     ///
     /// This method returns a reference to the data stored in the buffer as a slice of bytes.
     /// The length of the slice is determined by the `length` field of the `buffer` struct.
+    ///
+    /// The length is clamped to the buffer capacity, so even a corrupt or version-mismatched
+    /// driver response that reports an oversized length cannot cause a panic here.
     pub fn get_data(&self) -> &[u8] {
-        &self.buffer.0[..self.length as usize]
+        &self.buffer.0[..(self.length as usize).min(MAX_ETHER_FRAME)]
     }
 
     /// Returns a mutable reference to the data stored in the buffer.
     ///
     /// This method returns a mutable reference to the data stored in the buffer as a slice of bytes.
     /// The length of the slice is determined by the `length` field of the `buffer` struct.
+    ///
+    /// The length is clamped to the buffer capacity, so even a corrupt or version-mismatched
+    /// driver response that reports an oversized length cannot cause a panic here.
     pub fn get_data_mut(&mut self) -> &mut [u8] {
-        &mut self.buffer.0[..self.length as usize]
+        &mut self.buffer.0[..(self.length as usize).min(MAX_ETHER_FRAME)]
     }
 }
 

--- a/src/driver/filters.rs
+++ b/src/driver/filters.rs
@@ -15,7 +15,7 @@
 //! * [`TcpUdpFilter`] - Represents a static filter for TCP and UDP packets.
 //! * [`IcmpFilter`] - Represents a static filter for ICMP packets.
 //! * [`StaticFilter`] - Represents a single static filter entry that combines filter conditions for various
-//! layers and the filter action to be taken.
+//!   layers and the filter action to be taken.
 //! * [`StaticFilterTable`] - Represents a table of static filters, used for managing multiple static filter entries.
 
 // Import required external crates and types

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,11 +32,12 @@ pub use crate::ndisapi::{
     IpAddressV4, IpAddressV4Union, IpAddressV6, IpAddressV6Union, IpRangeV4, IpRangeV6, IpSubnetV4,
     IpSubnetV6, IpV4Filter, IpV4FilterFlags, IpV6Filter, IpV6FilterFlags, Ndisapi,
     NetworkAdapterInfo, NetworkLayerFilter, NetworkLayerFilterUnion, PacketOidData, PortRange,
-    RasLinks, StaticFilter, StaticFilterTable, StaticFilterWithPosition, TcpUdpFilter, TcpUdpFilterFlags,
-    TransportLayerFilter, TransportLayerFilterUnion, UnsortedReadRequest, UnsortedSendRequest,
-    Version, ETHER_ADDR_LENGTH, ETH_802_3, FILTER_PACKET_DROP, FILTER_PACKET_DROP_RDR,
-    FILTER_PACKET_PASS, FILTER_PACKET_PASS_RDR, FILTER_PACKET_REDIRECT, ICMP, IPV4, IPV6,
-    IP_RANGE_V4_TYPE, IP_RANGE_V6_TYPE, IP_SUBNET_V4_TYPE, IP_SUBNET_V6_TYPE, TCPUDP,
+    RasLinks, StaticFilter, StaticFilterTable, StaticFilterWithPosition, TcpUdpFilter,
+    TcpUdpFilterFlags, TransportLayerFilter, TransportLayerFilterUnion, UnsortedReadRequest,
+    UnsortedSendRequest, Version, ETHER_ADDR_LENGTH, ETH_802_3, FILTER_PACKET_DROP,
+    FILTER_PACKET_DROP_RDR, FILTER_PACKET_PASS, FILTER_PACKET_PASS_RDR, FILTER_PACKET_REDIRECT,
+    ICMP, IPV4, IPV6, IP_RANGE_V4_TYPE, IP_RANGE_V6_TYPE, IP_SUBNET_V4_TYPE, IP_SUBNET_V6_TYPE,
+    TCPUDP,
 };
 
 pub use crate::async_api::AsyncNdisapiAdapter;

--- a/src/ndisapi.rs
+++ b/src/ndisapi.rs
@@ -53,7 +53,13 @@ pub use crate::ndisapi::fastio_api::{IntermediateBufferArray, IntermediateBuffer
 /// For example, you can use the `Ndisapi::read_packets()` method to read packets from the network adapter, or the `Ndisapi::send_packets_to_adapter()`
 /// method to write packets to the network adapter. You can also use the `Ndisapi::set_packet_filter_table()` method to set a filter that specifies which
 /// packets should be captured or dropped.
-#[derive(Debug, Clone)]
+///
+/// `Ndisapi` owns the driver `HANDLE` and closes it in its `Drop` implementation. For this
+/// reason it deliberately does **not** implement `Clone`: copying the handle would allow one
+/// instance to close it while another is still using it, leading to a double-close or to
+/// operations on a reused OS handle. When shared ownership is required, wrap the instance in
+/// an [`std::sync::Arc`] (`Arc<Ndisapi>`), as the asynchronous API and examples do.
+#[derive(Debug)]
 pub struct Ndisapi {
     // Represents a handle to the NDIS filter driver.
     driver_handle: HANDLE,

--- a/src/ndisapi/base_api.rs
+++ b/src/ndisapi/base_api.rs
@@ -71,7 +71,8 @@ impl Ndisapi {
     pub fn get_hw_packet_filter(&self, adapter_handle: HANDLE) -> Result<u32> {
         let mut oid = PacketOidData::new(adapter_handle, OID_GEN_CURRENT_PACKET_FILTER, 0u32);
 
-        self.ndis_get_request::<_>(&mut oid)?;
+        // SAFETY: `T` is `u32`, a plain-old-data type for which every byte pattern is valid.
+        unsafe { self.ndis_get_request::<_>(&mut oid)? };
 
         Ok(oid.data)
     }
@@ -117,8 +118,8 @@ impl Ndisapi {
     /// # Returns
     ///
     /// * `Result<Vec<NetworkAdapterInfo>>` - A Result containing a vector of NetworkAdapterInfo
-    /// structs representing the available network interfaces if the query was successful,
-    /// or an error if it failed.
+    ///   structs representing the available network interfaces if the query was successful,
+    ///   or an error if it failed.
     pub fn get_tcpip_bound_adapters_info(&self) -> Result<Vec<NetworkAdapterInfo>> {
         let mut adapters: MaybeUninit<TcpAdapterList> = ::std::mem::MaybeUninit::uninit();
 
@@ -138,9 +139,15 @@ impl Ndisapi {
                 let mut result = Vec::new();
                 let adapters = unsafe { adapters.assume_init() };
 
-                for i in 0..adapters.adapter_count as usize {
-                    let adapter_name =
-                        String::from_utf8(adapters.adapter_name_list[i].to_vec()).unwrap();
+                // Clamp the driver-reported count to the static capacity of the list. A malformed
+                // or version-mismatched driver response could otherwise drive the loop past the
+                // bounds of the fixed-size arrays and panic.
+                let adapter_count = (adapters.adapter_count as usize).min(ADAPTER_LIST_SIZE);
+
+                for i in 0..adapter_count {
+                    // Adapter names are NUL-terminated byte strings. Use a lossy conversion so a
+                    // non-UTF-8 name from the driver cannot panic the enumeration.
+                    let adapter_name = String::from_utf8_lossy(&adapters.adapter_name_list[i]);
                     let adapter_name = adapter_name.trim_end_matches(char::from(0)).to_owned();
                     let next = NetworkAdapterInfo::new(
                         adapter_name,
@@ -206,7 +213,17 @@ impl Ndisapi {
     ///
     /// * `Result<()>` - A Result indicating whether the query operation was successful or not.
     ///   On success, returns `Ok(())`. On failure, returns an error.
-    pub fn ndis_get_request<T>(&self, oid_request: &mut PacketOidData<T>) -> Result<()> {
+    ///
+    /// # Safety
+    ///
+    /// The driver writes `size_of::<PacketOidData<T>>()` bytes back into `*oid_request` through
+    /// `DeviceIoControl`, overwriting the `data: T` field with arbitrary bytes. The caller must
+    /// guarantee that `T` is a "plain old data" type for which **every** byte pattern is a valid
+    /// value — for example integers or `#[repr(C)]` structs/arrays composed solely of such
+    /// types. Using a `T` that has validity invariants (`bool`, `char`, enums, references,
+    /// `NonZero*`, …) or that owns resources / implements `Drop` (`String`, `Vec`, `Box`, …) is
+    /// undefined behavior.
+    pub unsafe fn ndis_get_request<T>(&self, oid_request: &mut PacketOidData<T>) -> Result<()> {
         match unsafe {
             DeviceIoControl(
                 self.driver_handle,
@@ -241,7 +258,14 @@ impl Ndisapi {
     ///
     /// * `Result<()>` - A Result indicating whether the set operation was successful or not.
     ///   On success, returns `Ok(())`. On failure, returns an error.
-    pub fn ndis_set_request<T>(&self, oid_request: &PacketOidData<T>) -> Result<()> {
+    ///
+    /// # Safety
+    ///
+    /// The entire `PacketOidData<T>` (including the `data: T` field) is copied to the driver as
+    /// raw bytes. The caller must ensure `T` is a "plain old data" type so that no uninitialized
+    /// padding or values with validity invariants are exposed. Passing a type that owns
+    /// resources or implements `Drop` (`String`, `Vec`, `Box`, …) is undefined behavior.
+    pub unsafe fn ndis_set_request<T>(&self, oid_request: &PacketOidData<T>) -> Result<()> {
         match unsafe {
             DeviceIoControl(
                 self.driver_handle,
@@ -346,7 +370,8 @@ impl Ndisapi {
     pub fn set_hw_packet_filter(&self, adapter_handle: HANDLE, filter: u32) -> Result<()> {
         let oid = PacketOidData::new(adapter_handle, OID_GEN_CURRENT_PACKET_FILTER, filter);
 
-        self.ndis_set_request::<_>(&oid)?;
+        // SAFETY: `T` is `u32`, a plain-old-data type safe to copy to the driver.
+        unsafe { self.ndis_set_request::<_>(&oid)? };
 
         Ok(())
     }

--- a/src/ndisapi/base_api.rs
+++ b/src/ndisapi/base_api.rs
@@ -145,10 +145,17 @@ impl Ndisapi {
                 let adapter_count = (adapters.adapter_count as usize).min(ADAPTER_LIST_SIZE);
 
                 for i in 0..adapter_count {
-                    // Adapter names are NUL-terminated byte strings. Use a lossy conversion so a
-                    // non-UTF-8 name from the driver cannot panic the enumeration.
-                    let adapter_name = String::from_utf8_lossy(&adapters.adapter_name_list[i]);
-                    let adapter_name = adapter_name.trim_end_matches(char::from(0)).to_owned();
+                    // Adapter names are NUL-terminated C strings inside a fixed-size buffer.
+                    // Convert only the bytes up to the first NUL so any garbage following the
+                    // terminator is ignored, and use a lossy conversion so a non-UTF-8 name from
+                    // the driver cannot panic the enumeration.
+                    let name_bytes = &adapters.adapter_name_list[i];
+                    let name_len = name_bytes
+                        .iter()
+                        .position(|&b| b == 0)
+                        .unwrap_or(name_bytes.len());
+                    let adapter_name =
+                        String::from_utf8_lossy(&name_bytes[..name_len]).into_owned();
                     let next = NetworkAdapterInfo::new(
                         adapter_name,
                         adapters.adapter_handle[i],

--- a/src/ndisapi/static_api.rs
+++ b/src/ndisapi/static_api.rs
@@ -419,7 +419,9 @@ impl Ndisapi {
 
     /// Writes a `REG_DWORD` value to an open registry key.
     fn set_registry_dword(hkey: HKEY, value_name: PCWSTR, value: u32) -> Result<()> {
-        let bytes = value.to_ne_bytes();
+        // `REG_DWORD` is little-endian by definition; `to_le_bytes` documents that intent
+        // rather than relying on the host happening to be little-endian.
+        let bytes = value.to_le_bytes();
         unsafe { RegSetValueExW(hkey, value_name, Some(0), REG_DWORD, Some(&bytes)) }.ok()
     }
 

--- a/src/ndisapi/static_api.rs
+++ b/src/ndisapi/static_api.rs
@@ -11,12 +11,28 @@ use windows::{
     core::{s, w, Result, PCWSTR, PWSTR},
     Win32::System::Registry::{
         RegCloseKey, RegEnumKeyExW, RegOpenKeyExW, RegQueryValueExA, RegQueryValueExW,
-        RegSetValueExW, HKEY, HKEY_LOCAL_MACHINE, KEY_READ, KEY_WRITE, REG_DWORD, REG_VALUE_TYPE,
+        RegSetValueExW, HKEY, HKEY_LOCAL_MACHINE, KEY_READ, KEY_WRITE, REG_DWORD, REG_SAM_FLAGS,
+        REG_VALUE_TYPE,
     },
 };
 
 use super::Ndisapi;
+use std::mem::size_of;
 use std::str;
+
+/// A small RAII wrapper that closes an owned registry key (`HKEY`) when it goes out of scope.
+///
+/// Several registry helpers previously leaked their `HKEY` on the success path; wrapping the
+/// handle in this guard guarantees `RegCloseKey` is called on every exit path.
+struct RegKeyGuard(HKEY);
+
+impl Drop for RegKeyGuard {
+    fn drop(&mut self) {
+        // Closing an already-invalid handle simply fails and is harmless, but the guard is only
+        // ever constructed from a successfully opened key.
+        let _ = unsafe { RegCloseKey(self.0) };
+    }
+}
 
 /// The registry key path for the network control class.
 const REGSTR_NETWORK_CONTROL_CLASS: ::windows::core::PCWSTR =
@@ -276,7 +292,6 @@ impl Ndisapi {
     /// # Returns
     ///
     /// * `Result<String>`: Returns a `Result` containing the user-friendly name of the network adapter if found, or an error otherwise.
-
     pub fn get_friendly_adapter_name(adapter_name: impl Into<String>) -> Result<String> {
         let mut adapter_name = adapter_name.into();
 
@@ -353,6 +368,61 @@ impl Ndisapi {
         }
     }
 
+    /// Opens the driver's parameters registry key with the requested access rights.
+    ///
+    /// Returns a [`RegKeyGuard`] that closes the key when dropped, so callers never have to
+    /// remember to call `RegCloseKey` on every exit path.
+    fn open_driver_registry_key(&self, access: REG_SAM_FLAGS) -> Result<RegKeyGuard> {
+        let mut hkey = HKEY::default();
+
+        unsafe {
+            RegOpenKeyExW(
+                HKEY_LOCAL_MACHINE,
+                self.get_driver_registry_key(),
+                Some(0),
+                access,
+                &mut hkey,
+            )
+        }
+        .ok()?;
+
+        Ok(RegKeyGuard(hkey))
+    }
+
+    /// Reads a `REG_DWORD` value from an open registry key.
+    ///
+    /// Returns `None` if the value is missing, is not of type `REG_DWORD`, or is not exactly
+    /// four bytes long. The destination is a genuine `&mut u32`, so the kernel never writes
+    /// through a pointer derived from a shared reference (which would be undefined behavior).
+    fn query_registry_dword(hkey: HKEY, value_name: PCWSTR) -> Option<u32> {
+        let mut value_type = REG_VALUE_TYPE::default();
+        let mut value = 0u32;
+        let mut data_size = size_of::<u32>() as u32;
+
+        let result = unsafe {
+            RegQueryValueExW(
+                hkey,
+                value_name,
+                None,
+                Some(&mut value_type),
+                Some(&mut value as *mut u32 as *mut u8),
+                Some(&mut data_size),
+            )
+        };
+
+        if result.is_ok() && value_type == REG_DWORD && data_size as usize == size_of::<u32>() {
+            Some(value)
+        } else {
+            None
+        }
+    }
+
+    /// Writes a `REG_DWORD` value to an open registry key.
+    fn set_registry_dword(hkey: HKEY, value_name: PCWSTR, value: u32) -> Result<()> {
+        let bytes = value.to_ne_bytes();
+        unsafe { RegSetValueExW(hkey, value_name, Some(0), REG_DWORD, Some(&bytes)) }.ok()
+    }
+
     /// This function sets a parameter in the registry key that the filter driver reads during its initialization.
     /// The value set in the registry is subtracted from the actual MTU (Maximum Transmission Unit) when it is requested
     /// by the MSTCP (Microsoft TCP/IP) from the network. Because this parameter is read during the initialization of the
@@ -366,33 +436,8 @@ impl Ndisapi {
     ///
     /// * `Result<()>` - Returns a `Result` that is `Ok(())` if the MTU decrement value is set successfully in the registry, or an error otherwise.
     pub fn set_mtu_decrement(&self, mtu_decrement: u32) -> Result<()> {
-        let mut hkey = HKEY::default();
-
-        let mut result = unsafe {
-            RegOpenKeyExW(
-                HKEY_LOCAL_MACHINE,
-                self.get_driver_registry_key(),
-                Some(0),
-                KEY_WRITE,
-                &mut hkey,
-            )
-        }
-        .ok();
-
-        if result.is_ok() {
-            result = unsafe {
-                RegSetValueExW(
-                    hkey,
-                    REGSTR_MTU_DECREMENT,
-                    Some(0),
-                    REG_DWORD,
-                    Some(mtu_decrement.to_ne_bytes().as_ref()),
-                )
-            }
-            .ok();
-        }
-
-        result
+        let hkey = self.open_driver_registry_key(KEY_WRITE)?;
+        Self::set_registry_dword(hkey.0, REGSTR_MTU_DECREMENT, mtu_decrement)
     }
 
     /// This function retrieves the value set by `set_mtu_decrement` from the registry. Note that if you have not
@@ -403,40 +448,8 @@ impl Ndisapi {
     ///
     /// * `Option<u32>` - Returns an `Option` containing the MTU decrement value if it is present in the registry and there are no errors, or `None` otherwise.
     pub fn get_mtu_decrement(&self) -> Option<u32> {
-        let mut hkey = HKEY::default();
-
-        let mut result = unsafe {
-            RegOpenKeyExW(
-                HKEY_LOCAL_MACHINE,
-                self.get_driver_registry_key(),
-                Some(0),
-                KEY_READ,
-                &mut hkey,
-            )
-        };
-
-        let mut value_type = REG_VALUE_TYPE::default();
-        let mtu_decrement = 0u32;
-        let mut data_size = std::mem::size_of::<u32>() as u32;
-
-        if result.is_ok() {
-            result = unsafe {
-                RegQueryValueExW(
-                    hkey,
-                    REGSTR_MTU_DECREMENT,
-                    None,
-                    Some(&mut value_type),
-                    Some(&mtu_decrement as *const u32 as *mut u8),
-                    Some(&mut data_size),
-                )
-            };
-        }
-
-        if result.is_ok() {
-            Some(mtu_decrement)
-        } else {
-            None
-        }
+        let hkey = self.open_driver_registry_key(KEY_READ).ok()?;
+        Self::query_registry_dword(hkey.0, REGSTR_MTU_DECREMENT)
     }
 
     /// This routine sets the default mode to be applied to each adapter as soon as it appears in the system.
@@ -452,31 +465,8 @@ impl Ndisapi {
     ///
     /// * `Result<()>` - Returns a `Result` indicating whether the operation succeeded or an error occurred.
     pub fn set_adapters_startup_mode(&self, startup_mode: u32) -> Result<()> {
-        let mut hkey = HKEY::default();
-
-        let mut result = unsafe {
-            RegOpenKeyExW(
-                HKEY_LOCAL_MACHINE,
-                self.get_driver_registry_key(),
-                Some(0),
-                KEY_WRITE,
-                &mut hkey,
-            )
-        };
-
-        if result.is_ok() {
-            result = unsafe {
-                RegSetValueExW(
-                    hkey,
-                    REGSTR_STARTUP_MODE,
-                    Some(0),
-                    REG_DWORD,
-                    Some(startup_mode.to_ne_bytes().as_ref()),
-                )
-            };
-        }
-
-        result.ok()
+        let hkey = self.open_driver_registry_key(KEY_WRITE)?;
+        Self::set_registry_dword(hkey.0, REGSTR_STARTUP_MODE, startup_mode)
     }
 
     /// Returns the current default filter mode value applied to each adapter when it appears in the system.
@@ -487,40 +477,8 @@ impl Ndisapi {
     /// * `Option<u32>` - Returns the current default startup mode as `Some(u32)` if the value is present in the registry,
     ///   or `None` if the value is not present or an error occurred.
     pub fn get_adapters_startup_mode(&self) -> Option<u32> {
-        let mut hkey = HKEY::default();
-
-        let mut result = unsafe {
-            RegOpenKeyExW(
-                HKEY_LOCAL_MACHINE,
-                self.get_driver_registry_key(),
-                Some(0),
-                KEY_READ,
-                &mut hkey,
-            )
-        };
-
-        let mut value_type = REG_VALUE_TYPE::default();
-        let startup_mode = 0u32;
-        let mut data_size = std::mem::size_of::<u32>() as u32;
-
-        if result.is_ok() {
-            result = unsafe {
-                RegQueryValueExW(
-                    hkey,
-                    REGSTR_STARTUP_MODE,
-                    None,
-                    Some(&mut value_type),
-                    Some(&startup_mode as *const u32 as *mut u8),
-                    Some(&mut data_size),
-                )
-            };
-        }
-
-        if result.is_ok() {
-            Some(startup_mode)
-        } else {
-            None
-        }
+        let hkey = self.open_driver_registry_key(KEY_READ).ok()?;
+        Self::query_registry_dword(hkey.0, REGSTR_STARTUP_MODE)
     }
 
     /// Sets the pool size multiplier for Windows Packet Filter driver in the Windows registry.
@@ -540,31 +498,8 @@ impl Ndisapi {
     /// * `Result<()>` - If the pool size multiplier is successfully set, returns `Ok(())`.
     ///   Otherwise, returns an `Err` with the error code.
     pub fn set_pool_size(&self, pool_size: u32) -> Result<()> {
-        let mut hkey = HKEY::default();
-
-        let mut result = unsafe {
-            RegOpenKeyExW(
-                HKEY_LOCAL_MACHINE,
-                self.get_driver_registry_key(),
-                Some(0),
-                KEY_WRITE,
-                &mut hkey,
-            )
-        };
-
-        if result.is_ok() {
-            result = unsafe {
-                RegSetValueExW(
-                    hkey,
-                    REGSTR_POOL_SIZE,
-                    Some(0),
-                    REG_DWORD,
-                    Some(pool_size.to_ne_bytes().as_ref()),
-                )
-            };
-        }
-
-        result.ok()
+        let hkey = self.open_driver_registry_key(KEY_WRITE)?;
+        Self::set_registry_dword(hkey.0, REGSTR_POOL_SIZE, pool_size)
     }
 
     /// Retrieves the pool size multiplier for the Windows Packet Filter driver from the Windows registry.
@@ -579,39 +514,7 @@ impl Ndisapi {
     /// * `Option<u32>` - The pool size multiplier retrieved from the registry.
     ///   If the value is not found or an error occurs, returns `None`.
     pub fn get_pool_size(&self) -> Option<u32> {
-        let mut hkey = HKEY::default();
-
-        let mut result = unsafe {
-            RegOpenKeyExW(
-                HKEY_LOCAL_MACHINE,
-                self.get_driver_registry_key(),
-                Some(0),
-                KEY_READ,
-                &mut hkey,
-            )
-        };
-
-        let mut value_type = REG_VALUE_TYPE::default();
-        let pool_size = 0u32;
-        let mut data_size = std::mem::size_of::<u32>() as u32;
-
-        if result.is_ok() {
-            result = unsafe {
-                RegQueryValueExW(
-                    hkey,
-                    REGSTR_POOL_SIZE,
-                    None,
-                    Some(&mut value_type),
-                    Some(&pool_size as *const u32 as *mut u8),
-                    Some(&mut data_size),
-                )
-            };
-        }
-
-        if result.is_ok() {
-            Some(pool_size)
-        } else {
-            None
-        }
+        let hkey = self.open_driver_registry_key(KEY_READ).ok()?;
+        Self::query_registry_dword(hkey.0, REGSTR_POOL_SIZE)
     }
 }

--- a/src/netlib.rs
+++ b/src/netlib.rs
@@ -5,11 +5,11 @@
 //! # Submodules
 //!
 //! * [`ip_helper`] - Provides a set of helpers for working with the Windows IP Helper API.
-//! This includes types for working with network adapter information, IP gateway information, and
-//! socket address storage.
+//!   This includes types for working with network adapter information, IP gateway information, and
+//!   socket address storage.
 //!
 //! * [`net`] - Provides a set of networking utilities for Rust. This includes a type for
-//! representing MAC addresses.
+//!   representing MAC addresses.
 
 // Allowing unused imports in this module because they are re-exports
 // intended for end users of the library. These imports are not directly

--- a/src/netlib/ip_helper/if_luid.rs
+++ b/src/netlib/ip_helper/if_luid.rs
@@ -64,7 +64,7 @@ impl From<u64> for IfLuid {
     /// # Arguments
     ///
     /// * `value` - The u64 value that should be used to set the Value field of the NET_LUID_LH
-    ///             structure.
+    ///   structure.
     ///
     /// # Returns
     ///

--- a/src/netlib/ip_helper/network_adapter_info.rs
+++ b/src/netlib/ip_helper/network_adapter_info.rs
@@ -10,7 +10,7 @@ use windows::{
             },
             Ndis::{NDIS_MEDIUM, NDIS_PHYSICAL_MEDIUM},
         },
-        Networking::WinSock::{AF_INET, AF_INET6},
+        Networking::WinSock::{AF_INET, AF_INET6, SOCKET_ADDRESS},
         System::Registry::{
             RegCloseKey, RegOpenKeyExW, RegSetValueExW, HKEY, HKEY_LOCAL_MACHINE, KEY_WRITE, REG_SZ,
         },
@@ -78,6 +78,26 @@ pub struct IphlpNetworkAdapterInfo {
     ndis_wan_ipv6_link: MacAddress,
 }
 
+/// Converts a Windows `SOCKET_ADDRESS` (a `sockaddr` pointer plus its length) into an `IpAddr`.
+///
+/// The length is honored so IPv6 addresses (28-byte `SOCKADDR_IN6`) are not truncated to the
+/// 16-byte generic `SOCKADDR`. Returns `None` for a null/empty address or an unrecognized
+/// address family instead of panicking on data coming from the OS.
+///
+/// # Safety
+///
+/// `socket_address.lpSockaddr` must be null or point to at least `iSockaddrLength` valid,
+/// readable bytes.
+unsafe fn socket_address_to_ip(socket_address: &SOCKET_ADDRESS) -> Option<IpAddr> {
+    let storage = unsafe {
+        SockAddrStorage::from_raw_sockaddr(
+            socket_address.lpSockaddr,
+            socket_address.iSockaddrLength as usize,
+        )
+    }?;
+    storage.to_socket_addr().map(|socket_addr| socket_addr.ip())
+}
+
 impl IphlpNetworkAdapterInfo {
     /// Constructs a new `IphlpNetworkAdapterInfo` instance from raw pointers to `IP_ADAPTER_ADDRESSES_LH`
     /// and `MIB_IF_ROW2` structures.
@@ -117,31 +137,27 @@ impl IphlpNetworkAdapterInfo {
         let mut unicast_address_list = Vec::new();
         let mut unicast_address = address.FirstUnicastAddress;
         while !unicast_address.is_null() {
-            unicast_address_list.push(
-                SockAddrStorage::from_sockaddr(unsafe { *(*unicast_address).Address.lpSockaddr })
-                    .into(),
-            );
+            if let Some(ip) = unsafe { socket_address_to_ip(&(*unicast_address).Address) } {
+                unicast_address_list.push(ip);
+            }
             unicast_address = unsafe { (*unicast_address).Next };
         }
 
         let mut dns_server_address_list = Vec::new();
         let mut dns_address = address.FirstDnsServerAddress;
         while !dns_address.is_null() {
-            dns_server_address_list.push(
-                SockAddrStorage::from_sockaddr(unsafe { *(*dns_address).Address.lpSockaddr })
-                    .into(),
-            );
+            if let Some(ip) = unsafe { socket_address_to_ip(&(*dns_address).Address) } {
+                dns_server_address_list.push(ip);
+            }
             dns_address = unsafe { (*dns_address).Next };
         }
 
         let mut gateway_address_list = Vec::new();
         let mut gateway_address = address.FirstGatewayAddress;
         while !gateway_address.is_null() {
-            gateway_address_list.push(IpGatewayInfo::new(
-                SockAddrStorage::from_sockaddr(unsafe { *(*gateway_address).Address.lpSockaddr })
-                    .into(),
-                None,
-            ));
+            if let Some(ip) = unsafe { socket_address_to_ip(&(*gateway_address).Address) } {
+                gateway_address_list.push(IpGatewayInfo::new(ip, None));
+            }
             gateway_address = unsafe { (*gateway_address).Next };
         }
 
@@ -243,7 +259,7 @@ impl IphlpNetworkAdapterInfo {
     ///
     // This function sets the friendly name of a network adapter and updates the registry accordingly
     pub fn set_friendly_name(&mut self, friendly_name: impl Into<String>) -> Result<()> {
-        self.friendly_name = friendly_name.into(); // set the friendly name of the adapter to the input value
+        let friendly_name = friendly_name.into();
 
         // create the registry key path for the adapter's connection settings
         let friendly_name_key = format!(
@@ -254,6 +270,21 @@ impl IphlpNetworkAdapterInfo {
         // Convert the string to UTF16 array and get a pointer to it as PCWSTR
         let mut friendly_name_key = friendly_name_key.encode_utf16().collect::<Vec<u16>>();
         friendly_name_key.push(0); // add null terminator to end of key string
+
+        // A `REG_SZ` value is a NUL-terminated UTF-16 string. Encode the friendly name as
+        // UTF-16, append the terminator, and reinterpret the `u16` slice as the raw bytes
+        // expected by `RegSetValueExW`. Passing the UTF-8 bytes (as the previous code did)
+        // would write an invalid byte string and corrupt the adapter's display name.
+        let friendly_name_utf16: Vec<u16> = friendly_name
+            .encode_utf16()
+            .chain(std::iter::once(0))
+            .collect();
+        let friendly_name_bytes = unsafe {
+            std::slice::from_raw_parts(
+                friendly_name_utf16.as_ptr() as *const u8,
+                std::mem::size_of_val(friendly_name_utf16.as_slice()),
+            )
+        };
 
         let mut hkey = HKEY::default();
 
@@ -270,14 +301,14 @@ impl IphlpNetworkAdapterInfo {
 
         if result.is_ok() {
             // if the key was successfully opened
-            // set the AdapterName registry value to the friendly name of the adapter
+            // set the Name registry value to the friendly name of the adapter
             result = unsafe {
                 RegSetValueExW(
-                    hkey,                                // handle to an open registry key
-                    w!("Name"),                          // name of the value to be set
-                    Some(0),                             // reserved (ignored)
-                    REG_SZ,                              // data type of the value
-                    Some(self.friendly_name.as_bytes()), // pointer to the buffer containing the value's data
+                    hkey,                      // handle to an open registry key
+                    w!("Name"),                // name of the value to be set
+                    Some(0),                   // reserved (ignored)
+                    REG_SZ,                    // data type of the value
+                    Some(friendly_name_bytes), // UTF-16 bytes (incl. NUL terminator)
                 )
             };
 
@@ -286,7 +317,11 @@ impl IphlpNetworkAdapterInfo {
             };
         }
 
-        result.ok()
+        // Only update the cached friendly name once the registry write has succeeded, so the
+        // in-memory state stays consistent with what is persisted in the registry.
+        result.ok()?;
+        self.friendly_name = friendly_name;
+        Ok(())
     }
 
     /// Checks if IP address information in the provided network_adapter_info is different

--- a/src/netlib/ip_helper/network_adapter_info.rs
+++ b/src/netlib/ip_helper/network_adapter_info.rs
@@ -89,12 +89,11 @@ pub struct IphlpNetworkAdapterInfo {
 /// `socket_address.lpSockaddr` must be null or point to at least `iSockaddrLength` valid,
 /// readable bytes.
 unsafe fn socket_address_to_ip(socket_address: &SOCKET_ADDRESS) -> Option<IpAddr> {
-    let storage = unsafe {
-        SockAddrStorage::from_raw_sockaddr(
-            socket_address.lpSockaddr,
-            socket_address.iSockaddrLength as usize,
-        )
-    }?;
+    // `iSockaddrLength` is a signed `i32`. Reject non-positive lengths via `try_from` so a
+    // negative value cannot wrap to a huge `usize` and make `from_raw_sockaddr` read past the
+    // end of the source sockaddr.
+    let len = usize::try_from(socket_address.iSockaddrLength).ok()?;
+    let storage = unsafe { SockAddrStorage::from_raw_sockaddr(socket_address.lpSockaddr, len) }?;
     storage.to_socket_addr().map(|socket_addr| socket_addr.ip())
 }
 

--- a/src/netlib/ip_helper/network_adapter_info/address.rs
+++ b/src/netlib/ip_helper/network_adapter_info/address.rs
@@ -182,14 +182,17 @@ impl IphlpNetworkAdapterInfo {
 
         match unsafe { GetUnicastIpAddressTable(AF_UNSPEC, &mut table) }.ok() {
             Ok(_) => {
+                // Accumulate per-entry results so a single failed deletion is reported instead of
+                // being masked by an unconditional `true`.
+                let mut success = true;
                 for i in 0..unsafe { (*table).NumEntries } {
                     let entry = unsafe { &mut (*table).Table[i as usize] };
                     if IfLuid::from(entry.InterfaceLuid) == self.luid {
-                        let _ = unsafe { DeleteUnicastIpAddressEntry(entry) };
+                        success &= unsafe { DeleteUnicastIpAddressEntry(entry) }.is_ok();
                     }
                 }
                 unsafe { FreeMibTable(table as *mut _) };
-                true
+                success
             }
             Err(_) => false,
         }
@@ -215,6 +218,9 @@ impl IphlpNetworkAdapterInfo {
 
         match unsafe { GetUnicastIpAddressTable(AF_INET, &mut table) }.ok() {
             Ok(_) => {
+                // Report failure if a matching entry could not be deleted instead of always
+                // returning `true`.
+                let mut success = true;
                 for i in 0..unsafe { (*table).NumEntries } {
                     let entry = unsafe { &(*table).Table[i as usize] };
 
@@ -223,12 +229,12 @@ impl IphlpNetworkAdapterInfo {
                             unsafe { entry.Address.Ipv4.sin_addr.S_un.S_addr }.to_ne_bytes(),
                         ) == address
                     {
-                        let _ = unsafe { DeleteUnicastIpAddressEntry(entry) };
+                        success &= unsafe { DeleteUnicastIpAddressEntry(entry) }.is_ok();
                     }
                 }
 
                 unsafe { FreeMibTable(table as *mut _) };
-                true
+                success
             }
             Err(_) => false,
         }
@@ -254,18 +260,21 @@ impl IphlpNetworkAdapterInfo {
 
         match unsafe { GetUnicastIpAddressTable(AF_INET6, &mut table) }.ok() {
             Ok(_) => {
+                // Report failure if a matching entry could not be deleted instead of always
+                // returning `true`.
+                let mut success = true;
                 for i in 0..unsafe { (*table).NumEntries } {
                     let entry = unsafe { &(*table).Table[i as usize] };
 
                     if IfLuid::from(entry.InterfaceLuid) == self.luid
                         && Ipv6Addr::from(unsafe { entry.Address.Ipv6.sin6_addr.u.Byte }) == address
                     {
-                        let _ = unsafe { DeleteUnicastIpAddressEntry(entry) };
+                        success &= unsafe { DeleteUnicastIpAddressEntry(entry) }.is_ok();
                     }
                 }
 
                 unsafe { FreeMibTable(table as *mut _) };
-                true
+                success
             }
             Err(_) => false,
         }

--- a/src/netlib/ip_helper/network_adapter_info/ndp.rs
+++ b/src/netlib/ip_helper/network_adapter_info/ndp.rs
@@ -36,7 +36,10 @@ impl IphlpNetworkAdapterInfo {
 
         net_row.Address.si_family = AF_INET;
         net_row.Address.Ipv4.sin_family = AF_INET;
-        net_row.Address.Ipv4.sin_addr.S_un.S_addr = u32::from(address);
+        // Store the octets in network byte order, consistent with `add_unicast_address_ipv4`
+        // and `add_routes_ipv4`. Using `u32::from(address)` here wrote the bytes in host order,
+        // which reversed the address on little-endian Windows.
+        net_row.Address.Ipv4.sin_addr.S_un.S_addr = u32::from_ne_bytes(address.octets());
         net_row.InterfaceIndex = self.if_index;
         net_row.InterfaceLuid = self.luid.into();
         net_row.PhysicalAddress.copy_from_slice(&hw_address);

--- a/src/netlib/ip_helper/network_adapter_info/routing.rs
+++ b/src/netlib/ip_helper/network_adapter_info/routing.rs
@@ -161,7 +161,10 @@ impl IphlpNetworkAdapterInfo {
         let mut status = true;
 
         for address in addresses.iter() {
-            status = unsafe { DeleteIpForwardEntry2(address) }.is_ok()
+            // Accumulate failures: every entry must be deleted for the call to report success.
+            // Previously the result of the final iteration overwrote all earlier ones, hiding
+            // partial failures.
+            status &= unsafe { DeleteIpForwardEntry2(address) }.is_ok();
         }
 
         status
@@ -185,16 +188,19 @@ impl IphlpNetworkAdapterInfo {
             Ok(_) => {
                 let num_entries = unsafe { (*table).NumEntries };
 
+                // Track whether every matching route was removed successfully rather than
+                // unconditionally returning `true` and silently dropping individual failures.
+                let mut success = true;
                 for i in 0..num_entries {
                     let entry = unsafe { &mut (*table).Table[i as usize] };
 
                     if IfLuid::from(entry.InterfaceLuid) == self.luid {
-                        let _ = unsafe { DeleteIpForwardEntry2(entry) };
+                        success &= unsafe { DeleteIpForwardEntry2(entry) }.is_ok();
                     }
                 }
 
                 unsafe { FreeMibTable(table as *mut _) };
-                true
+                success
             }
             Err(_) => false,
         }

--- a/src/netlib/ip_helper/sockaddr_storage.rs
+++ b/src/netlib/ip_helper/sockaddr_storage.rs
@@ -98,8 +98,13 @@ impl SockAddrStorage {
         Ok(Self(sockaddr_storage))
     }
 
-    /// Builds an `IN_ADDR` from an `Ipv4Addr`, storing the four octets in network byte order
-    /// (the in-memory layout the Windows socket APIs expect) regardless of host endianness.
+    /// Builds an `IN_ADDR` from an `Ipv4Addr`.
+    ///
+    /// `u32::from_ne_bytes(address.octets())` lays the four octets out in memory as
+    /// `[a, b, c, d]` (first octet at the lowest address) regardless of host endianness, which
+    /// is the on-the-wire octet order `IN_ADDR.S_un.S_addr` is required to hold. This is about
+    /// the byte layout of the field, not the numeric value of the `u32` (that value differs by
+    /// host endianness, but the stored bytes do not).
     ///
     /// Centralizing this conversion keeps every `SockAddrStorage` constructor consistent.
     /// Previously the constructors disagreed: `from_ipv4_addr` used `to_be()` while

--- a/src/netlib/ip_helper/sockaddr_storage.rs
+++ b/src/netlib/ip_helper/sockaddr_storage.rs
@@ -101,10 +101,11 @@ impl SockAddrStorage {
     /// Builds an `IN_ADDR` from an `Ipv4Addr`, storing the four octets in network byte order
     /// (the in-memory layout the Windows socket APIs expect) regardless of host endianness.
     ///
-    /// Centralizing this conversion keeps every `SockAddrStorage` constructor consistent. An
-    /// earlier version of `socket_addr_to_sockaddr_storage` stored the address in host byte
-    /// order (`to_le`), which reversed IPv4 addresses parsed from strings on little-endian
-    /// Windows relative to the addresses produced by `from_ipv4_addr`.
+    /// Centralizing this conversion keeps every `SockAddrStorage` constructor consistent.
+    /// Previously the constructors disagreed: `from_ipv4_addr` used `to_be()` while
+    /// `socket_addr_to_sockaddr_storage` used `to_le()`, so on little-endian Windows the octets
+    /// ended up reversed and the same IPv4 address built from a string did not match one built
+    /// from an `Ipv4Addr`.
     fn ipv4_to_in_addr(address: Ipv4Addr) -> IN_ADDR {
         IN_ADDR {
             S_un: IN_ADDR_0 {
@@ -226,13 +227,8 @@ impl SockAddrStorage {
 
     /// Constructs a new `SockAddrStorage` from a `SOCKADDR_IN` struct.
     ///
-    /// # Safety
-    ///
-    /// This function uses `MaybeUninit` to safely create an uninitialized
-    /// `SOCKADDR_STORAGE` instance, and then it copies the `SOCKADDR_IN` contents
-    /// into the `SOCKADDR_STORAGE` without overlapping.
-    /// Before constructing the `SockAddrStorage`, it ensures that the contents
-    /// are valid using the `assume_init()` method.
+    /// The storage is fully zero-initialized and the `SOCKADDR_IN` is copied over its leading
+    /// bytes, so the result is always fully initialized.
     pub fn from_sockaddr_in(address: SOCKADDR_IN) -> Self {
         // Zero-initialize the storage so the bytes beyond `SOCKADDR_IN` are well-defined, then
         // copy the source over the leading bytes.
@@ -253,13 +249,8 @@ impl SockAddrStorage {
 
     /// Constructs a new `SockAddrStorage` from a `SOCKADDR_IN6` struct.
     ///
-    /// # Safety
-    ///
-    /// This function uses `MaybeUninit` to safely create an uninitialized
-    /// `SOCKADDR_STORAGE` instance, and then it copies the `SOCKADDR_IN6` contents
-    /// into the `SOCKADDR_STORAGE` without overlapping.
-    /// Before constructing the `SockAddrStorage`, it ensures that the contents
-    /// are valid using the `assume_init()` method.
+    /// The storage is fully zero-initialized and the `SOCKADDR_IN6` is copied over its leading
+    /// bytes, so the result is always fully initialized.
     pub fn from_sockaddr_in6(address: SOCKADDR_IN6) -> Self {
         // Zero-initialize the storage so the bytes beyond `SOCKADDR_IN6` are well-defined, then
         // copy the source over the leading bytes.

--- a/src/netlib/ip_helper/sockaddr_storage.rs
+++ b/src/netlib/ip_helper/sockaddr_storage.rs
@@ -14,7 +14,6 @@
 //! assert_eq!(socket_addr.ip(), ipv4_addr);
 //! ```
 
-use std::mem::MaybeUninit;
 use std::{
     mem,
     net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6},
@@ -44,9 +43,7 @@ impl PartialEq for SockAddrStorage {
                 let other_addr: &SOCKADDR_IN =
                     unsafe { &*(&other.0 as *const _ as *const SOCKADDR_IN) };
                 self_addr.sin_port == other_addr.sin_port
-                    && unsafe {
-                        self_addr.sin_addr.S_un.S_addr == other_addr.sin_addr.S_un.S_addr
-                    }
+                    && unsafe { self_addr.sin_addr.S_un.S_addr == other_addr.sin_addr.S_un.S_addr }
             }
             AF_INET6 => {
                 let self_addr: &SOCKADDR_IN6 =
@@ -101,6 +98,21 @@ impl SockAddrStorage {
         Ok(Self(sockaddr_storage))
     }
 
+    /// Builds an `IN_ADDR` from an `Ipv4Addr`, storing the four octets in network byte order
+    /// (the in-memory layout the Windows socket APIs expect) regardless of host endianness.
+    ///
+    /// Centralizing this conversion keeps every `SockAddrStorage` constructor consistent. An
+    /// earlier version of `socket_addr_to_sockaddr_storage` stored the address in host byte
+    /// order (`to_le`), which reversed IPv4 addresses parsed from strings on little-endian
+    /// Windows relative to the addresses produced by `from_ipv4_addr`.
+    fn ipv4_to_in_addr(address: Ipv4Addr) -> IN_ADDR {
+        IN_ADDR {
+            S_un: IN_ADDR_0 {
+                S_addr: u32::from_ne_bytes(address.octets()),
+            },
+        }
+    }
+
     /// Converts a `SocketAddr` to a `SOCKADDR_STORAGE` structure.
     ///
     /// # Arguments
@@ -119,11 +131,7 @@ impl SockAddrStorage {
                 let sockaddr_in: SOCKADDR_IN = SOCKADDR_IN {
                     sin_family: AF_INET,
                     sin_port: 0,
-                    sin_addr: IN_ADDR {
-                        S_un: IN_ADDR_0 {
-                            S_addr: u32::from(ipv4_addr).to_le(),
-                        },
-                    },
+                    sin_addr: Self::ipv4_to_in_addr(ipv4_addr),
                     sin_zero: [0; 8],
                 };
 
@@ -158,34 +166,62 @@ impl SockAddrStorage {
 
     /// Constructs a new `SockAddrStorage` from a `SOCKADDR` struct.
     ///
-    /// # Safety
-    ///
-    /// This function uses `MaybeUninit` to safely create an uninitialized
-    /// `SOCKADDR_STORAGE` instance, and then it copies the `SOCKADDR` contents
-    /// into the `SOCKADDR_STORAGE` without overlapping.
-    /// Before constructing the `SockAddrStorage`, it ensures that the contents
-    /// are valid using the `assume_init()` method.
+    /// Note that a by-value `SOCKADDR` is only 16 bytes and therefore cannot carry an IPv6
+    /// address; prefer [`from_raw_sockaddr`](Self::from_raw_sockaddr) when converting the
+    /// `SOCKET_ADDRESS` values returned by the Windows IP Helper API, as it honors the actual
+    /// address length.
     pub fn from_sockaddr(address: SOCKADDR) -> Self {
-        // Create a `MaybeUninit` instance for `SOCKADDR_STORAGE`.
-        let mut storage: MaybeUninit<SOCKADDR_STORAGE> = MaybeUninit::uninit();
+        // Start from a fully zeroed storage so any bytes beyond the `SOCKADDR` are well-defined
+        // rather than uninitialized (the previous implementation `assume_init`-ed a partially
+        // copied buffer, leaving the trailing bytes uninitialized and reads of them undefined).
+        let mut storage: SOCKADDR_STORAGE = unsafe { mem::zeroed() };
 
-        // Get pointers to the `SOCKADDR` and `SOCKADDR_STORAGE` instances.
-        let src_ptr = &address as *const _ as *const u8;
-        let dst_ptr = storage.as_mut_ptr() as *mut u8;
-
-        // Copy the `SOCKADDR` contents into the `SOCKADDR_STORAGE` without overlapping.
         // # Safety: The source and destination pointers are non-overlapping, and
         // the size of the `SOCKADDR` struct is known at compile-time.
         unsafe {
-            std::ptr::copy_nonoverlapping(src_ptr, dst_ptr, std::mem::size_of::<SOCKADDR>());
+            std::ptr::copy_nonoverlapping(
+                &address as *const _ as *const u8,
+                &mut storage as *mut _ as *mut u8,
+                std::mem::size_of::<SOCKADDR>(),
+            );
         }
 
-        // Ensure that the contents are valid before constructing the `SockAddrStorage`.
-        // # Safety: `storage` has been properly initialized by the `copy_nonoverlapping`
-        // function above, so it's safe to call `assume_init()`.
-        let storage = unsafe { storage.assume_init() };
-
         SockAddrStorage(storage)
+    }
+
+    /// Constructs a new `SockAddrStorage` from a raw `SOCKADDR` pointer and its byte length.
+    ///
+    /// This is the correct way to convert the `SOCKET_ADDRESS` values returned by the Windows
+    /// IP Helper API. The pointed-to structure is a family-specific socket address
+    /// (`SOCKADDR_IN` for IPv4, `SOCKADDR_IN6` for IPv6) whose real size is reported by the
+    /// `iSockaddrLength` field. Dereferencing the pointer as a by-value 16-byte `SOCKADDR`
+    /// truncates IPv6 addresses, which is why this length-aware variant exists.
+    ///
+    /// Returns `None` if `sockaddr` is null or `len` is zero.
+    ///
+    /// # Safety
+    ///
+    /// `sockaddr` must either be null or point to at least `len` initialized, readable bytes
+    /// that remain valid for the duration of the call.
+    pub unsafe fn from_raw_sockaddr(sockaddr: *const SOCKADDR, len: usize) -> Option<Self> {
+        if sockaddr.is_null() || len == 0 {
+            return None;
+        }
+
+        // Zero-initialize first, then copy only the bytes the source actually holds, capped at
+        // the storage capacity. Any uncopied trailing bytes stay well-defined (zero).
+        let mut storage: SOCKADDR_STORAGE = unsafe { mem::zeroed() };
+        let copy_len = len.min(std::mem::size_of::<SOCKADDR_STORAGE>());
+
+        unsafe {
+            std::ptr::copy_nonoverlapping(
+                sockaddr as *const u8,
+                &mut storage as *mut _ as *mut u8,
+                copy_len,
+            );
+        }
+
+        Some(SockAddrStorage(storage))
     }
 
     /// Constructs a new `SockAddrStorage` from a `SOCKADDR_IN` struct.
@@ -198,24 +234,19 @@ impl SockAddrStorage {
     /// Before constructing the `SockAddrStorage`, it ensures that the contents
     /// are valid using the `assume_init()` method.
     pub fn from_sockaddr_in(address: SOCKADDR_IN) -> Self {
-        // Create a `MaybeUninit` instance for `SOCKADDR_STORAGE`.
-        let mut storage: MaybeUninit<SOCKADDR_STORAGE> = MaybeUninit::uninit();
+        // Zero-initialize the storage so the bytes beyond `SOCKADDR_IN` are well-defined, then
+        // copy the source over the leading bytes.
+        let mut storage: SOCKADDR_STORAGE = unsafe { mem::zeroed() };
 
-        // Get pointers to the `SOCKADDR_IN` and `SOCKADDR_STORAGE` instances.
-        let src_ptr = &address as *const _ as *const u8;
-        let dst_ptr = storage.as_mut_ptr() as *mut u8;
-
-        // Copy the `SOCKADDR_IN` contents into the `SOCKADDR_STORAGE` without overlapping.
         // # Safety: The source and destination pointers are non-overlapping, and
         // the size of the `SOCKADDR_IN` struct is known at compile-time.
         unsafe {
-            std::ptr::copy_nonoverlapping(src_ptr, dst_ptr, std::mem::size_of::<SOCKADDR_IN>());
+            std::ptr::copy_nonoverlapping(
+                &address as *const _ as *const u8,
+                &mut storage as *mut _ as *mut u8,
+                std::mem::size_of::<SOCKADDR_IN>(),
+            );
         }
-
-        // Ensure that the contents are valid before constructing the `SockAddrStorage`.
-        // # Safety: `storage` has been properly initialized by the `copy_nonoverlapping`
-        // function above, so it's safe to call `assume_init()`.
-        let storage = unsafe { storage.assume_init() };
 
         SockAddrStorage(storage)
     }
@@ -230,39 +261,29 @@ impl SockAddrStorage {
     /// Before constructing the `SockAddrStorage`, it ensures that the contents
     /// are valid using the `assume_init()` method.
     pub fn from_sockaddr_in6(address: SOCKADDR_IN6) -> Self {
-        // Create a `MaybeUninit` instance for `SOCKADDR_STORAGE`.
-        let mut storage: MaybeUninit<SOCKADDR_STORAGE> = MaybeUninit::uninit();
+        // Zero-initialize the storage so the bytes beyond `SOCKADDR_IN6` are well-defined, then
+        // copy the source over the leading bytes.
+        let mut storage: SOCKADDR_STORAGE = unsafe { mem::zeroed() };
 
-        // Get pointers to the `SOCKADDR_IN6` and `SOCKADDR_STORAGE` instances.
-        let src_ptr = &address as *const _ as *const u8;
-        let dst_ptr = storage.as_mut_ptr() as *mut u8;
-
-        // Copy the `SOCKADDR_IN6` contents into the `SOCKADDR_STORAGE` without overlapping.
         // # Safety: The source and destination pointers are non-overlapping, and
         // the size of the `SOCKADDR_IN6` struct is known at compile-time.
         unsafe {
-            std::ptr::copy_nonoverlapping(src_ptr, dst_ptr, std::mem::size_of::<SOCKADDR_IN6>());
+            std::ptr::copy_nonoverlapping(
+                &address as *const _ as *const u8,
+                &mut storage as *mut _ as *mut u8,
+                std::mem::size_of::<SOCKADDR_IN6>(),
+            );
         }
-
-        // Ensure that the contents are valid before constructing the `SockAddrStorage`.
-        // # Safety: `storage` has been properly initialized by the `copy_nonoverlapping`
-        // function above, so it's safe to call `assume_init()`.
-        let storage = unsafe { storage.assume_init() };
 
         SockAddrStorage(storage)
     }
 
     /// Constructs a new `SockAddrStorage` from an `Ipv4Addr` object.
     pub fn from_ipv4_addr(address: Ipv4Addr) -> Self {
-        let in_addr = IN_ADDR {
-            S_un: IN_ADDR_0 {
-                S_addr: u32::from(address).to_be(),
-            },
-        };
         let sockaddr = SOCKADDR_IN {
             sin_family: AF_INET,
             sin_port: 0,
-            sin_addr: in_addr,
+            sin_addr: Self::ipv4_to_in_addr(address),
             sin_zero: [0; 8],
         };
         SockAddrStorage::from_sockaddr_in(sockaddr)
@@ -577,5 +598,40 @@ mod tests {
         let ipv4 = SockAddrStorage::from_ipv4_addr(Ipv4Addr::new(127, 0, 0, 1));
         let ipv6 = SockAddrStorage::from_ipv6_addr(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1));
         assert_ne!(ipv4, ipv6);
+    }
+
+    #[test]
+    fn test_ipv4_stored_in_network_order() {
+        // The `S_addr` field must hold the octets in network byte order (first octet at the
+        // lowest address), which is what the Windows socket APIs expect.
+        let info = SockAddrStorage::from_ipv4_addr(Ipv4Addr::new(1, 2, 3, 4));
+        let sockaddr_in: &SOCKADDR_IN = unsafe { &*(&info.0 as *const _ as *const SOCKADDR_IN) };
+        let bytes = unsafe { sockaddr_in.sin_addr.S_un.S_addr }.to_ne_bytes();
+        assert_eq!(bytes, [1, 2, 3, 4]);
+    }
+
+    #[test]
+    fn test_from_ip_string_ipv4_roundtrip() {
+        let info = SockAddrStorage::from_ip_string("192.168.1.2").unwrap();
+        match info.to_socket_addr().unwrap() {
+            SocketAddr::V4(v4) => assert_eq!(*v4.ip(), Ipv4Addr::new(192, 168, 1, 2)),
+            _ => panic!("Expected SocketAddr::V4"),
+        }
+        // The string-based and `Ipv4Addr`-based constructors must agree on byte order.
+        assert_eq!(
+            info,
+            SockAddrStorage::from_ipv4_addr(Ipv4Addr::new(192, 168, 1, 2))
+        );
+    }
+
+    #[test]
+    fn test_from_ip_string_ipv6_roundtrip() {
+        let expected = Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 1);
+        let info = SockAddrStorage::from_ip_string("2001:db8::1").unwrap();
+        match info.to_socket_addr().unwrap() {
+            SocketAddr::V6(v6) => assert_eq!(*v6.ip(), expected),
+            _ => panic!("Expected SocketAddr::V6"),
+        }
+        assert_eq!(info, SockAddrStorage::from_ipv6_addr(expected));
     }
 }


### PR DESCRIPTION
## Summary

Addresses safety, correctness, and robustness findings from a review of the Win32/driver boundary, and bumps the crate to **0.7.0**. Every finding was reviewed and validated before fixing; the change set builds clean and passes `fmt`/`clippy -D warnings`/`test`.

## ⚠️ Breaking changes
- **`Ndisapi` no longer implements `Clone`.** It owns the driver `HANDLE` and closes it on `Drop`, so cloning risked a double-close / use of a reused OS handle. Use `Arc<Ndisapi>` for shared ownership (the async API and examples already do).
- **`ndis_get_request` / `ndis_set_request` are now `unsafe fn`.** The driver reads/writes the generic `T` as raw bytes, so `T` must be plain-old-data. The safe `u32` wrappers (`get_hw_packet_filter` / `set_hw_packet_filter`) are unchanged.

## Fixes

### Critical
- **IPv6 truncation + uninitialized memory** (`sockaddr_storage.rs`, `network_adapter_info.rs`): added length-aware `from_raw_sockaddr(*const SOCKADDR, len)` and switched adapter enumeration to it so IPv6 addresses are no longer truncated to a 16-byte `SOCKADDR`; all `from_sockaddr*` constructors now zero-initialize the storage.
- **Unsound generic OID API** and **`Ndisapi: Clone` double-close**: see Breaking changes.

### High
- **Async event-stream races** (`win32_event_stream.rs`): the waker is registered before the readiness re-check (lost-wakeup fix); `UnregisterWaitEx(.., INVALID_HANDLE_VALUE)` waits for in-flight callbacks, and on failure deliberately leaks instead of freeing the callback / closing the event (avoids use-after-free / use-after-close).
- **Async event-handle leak** (`async_api.rs`): `AsyncNdisapiAdapter::new` no longer leaks the event on partial construction.
- **Registry getter UB + `HKEY` leak** (`static_api.rs`): getters now write through a real `&mut`, validate `REG_DWORD`/size, and always close the key via an RAII guard.
- **`set_friendly_name` wrote UTF-8 as `REG_SZ`** (`network_adapter_info.rs`): now writes UTF-16 and updates the cached name only after the write succeeds.

### Medium
- `IntermediateBuffer::set_length` clamps to `MAX_ETHER_FRAME`; data accessors clamp defensively (no panics).
- Centralized IPv4 -> `IN_ADDR` conversion to network byte order (the `from_ip_string` path stored host order, reversing addresses on little-endian Windows); fixed `add_ndp_entry_ipv4`; added round-trip tests.
- `delete_routes` / `reset_*` / `delete_unicast_address_*` accumulate per-entry failures instead of masking them.
- `get_tcpip_bound_adapters_info` clamps the driver-reported count to `ADAPTER_LIST_SIZE` and uses lossy UTF-8 for names.
- Async batch send (`send_packets_to_adapter`/`mstcp`) returns the number of packets submitted instead of the always-zero `packet_success` counter.

## Version
`0.6.6` -> `0.7.0` (minor bump signals the breaking changes per 0.x semver) in `Cargo.toml` and `README.md`.

## Verification
- `cargo build --all-targets` - pass
- `cargo test` - pass (31 unit + 8 doctests; driver-dependent tests are `#[ignore]`d)
- `cargo fmt --check` - pass
- `cargo clippy -- -D warnings` - pass (also fixed pre-existing doc-comment lints)