### PR TITLE
ci: bump GitHub Actions to current major versions

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -11,7 +11,7 @@ categories:
       - "bugfix"
       - "bug"
   - title: "🧰 Maintenance"
-    label:
+    labels:
       - "chore"
       - "dependencies"
   - title: "📝 Documentation"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
     outputs:
       tag_name: ${{ steps.release_drafter.outputs.tag_name }}
     steps:
-      - uses: release-drafter/release-drafter@v5
+      - uses: release-drafter/release-drafter@v7
         id: release_drafter
         env:
           GITHUB_TOKEN: ${{ secrets.NDISAPI_PAT_TOKEN }}
@@ -32,8 +32,8 @@ jobs:
     runs-on: ${{ matrix.runs-on }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
-      - uses: actions/cache@v3
+        uses: actions/checkout@v7
+      - uses: actions/cache@v6
         with:
           path: |
             ~/.cargo/.crates.toml

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ${{ matrix.runs-on }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
 
       - name: Update toolchain
         run: |
@@ -34,7 +34,7 @@ jobs:
     runs-on: windows-2022
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
 
       - name: Update toolchain
         run: |


### PR DESCRIPTION
## Summary

The `0.7.0` publish run logged **Node.js 20 deprecation warnings** for `actions/checkout@v3` (GitHub is forcing those onto Node 24 and will eventually drop Node 20). This bumps the workflow actions to their current major versions, which run on Node 24:

| Action | Before | After |
|---|---|---|
| `actions/checkout` | v3 | **v7** (`build.yml`, `publish.yml`) |
| `actions/cache` | v3 | **v6** (`build.yml`) |
| `release-drafter/release-drafter` | v5 | **v7** (`build.yml`) |

(Note: `@v4`/`@v5` of checkout still target Node 20, so v7 is needed to actually clear the warning.)

## Validation

This PR''s own `build.yml` run exercises all three: it checks out with `checkout@v7`, restores the cargo cache via `cache@v6`, and runs the `draft-release` job on `release-drafter@v7`. No source/library changes — workflow YAML only.